### PR TITLE
chore: correct minor spelling mistake in package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "astor-antfustyle-theme",
+  "name": "astro-antfustyle-theme",
   "version": "1.2.0",
   "type": "module",
   "private": true,


### PR DESCRIPTION
minor bugfix for `package.json`, switching *astor* to *astro*