### PR TITLE
feat(custom): add `UI.externalLink` option to customize external link behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "rehype-callouts": "^1.4.1",
     "rehype-external-links": "^3.0.0",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
     "remark-directive": "^3.0.0",
     "remark-imgattr": "^1.0.5",
     "remark-math": "^6.0.0",

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -7,6 +7,7 @@ import remarkMath from 'remark-math'
 import remarkReadingTime from './remark-reading-time'
 import remarkGenerateOgImage from './remark-generate-og-image'
 
+import rehypeRaw from 'rehype-raw'
 import { rehypeHeadingIds } from '@astrojs/markdown-remark'
 import rehypeCallouts from 'rehype-callouts'
 import rehypeKatex from 'rehype-katex'
@@ -34,6 +35,8 @@ export const remarkPlugins: RemarkPlugins = [
 ]
 
 export const rehypePlugins: RehypePlugins = [
+  // https://github.com/rehypejs/rehype-raw
+  rehypeRaw,
   // https://docs.astro.build/en/guides/markdown-content/#heading-ids-and-plugins
   rehypeHeadingIds,
   // https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
@@ -83,7 +86,7 @@ export const rehypePlugins: RehypePlugins = [
 
         return {
           'u-i-carbon-arrow-up-right': true,
-          'class': 'new-tab-icon',
+          'className': ['new-tab-icon'],
           'aria-hidden': 'true',
         }
       },
@@ -102,9 +105,9 @@ export const rehypePlugins: RehypePlugins = [
           UI.externalLink.cursorType.length > 0 &&
           UI.externalLink.cursorType !== 'pointer'
         ) {
-          props.class = el.properties.class
-            ? `${el.properties.class} external-link-cursor`
-            : 'external-link-cursor'
+          props.className = Array.isArray(el.properties.className)
+            ? [...el.properties.className, 'external-link-cursor']
+            : ['external-link-cursor']
         }
 
         return props

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -49,21 +49,11 @@ export const rehypePlugins: RehypePlugins = [
   [
     rehypeExternalLinks,
     {
-      rel: 'noopener noreferrer',
+      rel: UI.externalLink.newTab ? 'noopener noreferrer' : [],
       content: (el: Parameters<CreateProperties>[0]) => {
         if (!UI.externalLink.newTab || !UI.externalLink.showNewTabIcon)
           return null
 
-        // ignore remark-directive-sugar generated links
-        const elClass = el.properties.class
-        if (
-          elClass &&
-          typeof elClass === 'string' &&
-          elClass.includes('sugar-link')
-        )
-          return null
-
-        // ignore links containing images
         let hasImage = false
         visit(el, 'element', (childNode) => {
           if (childNode.tagName === 'img') {
@@ -82,16 +72,6 @@ export const rehypePlugins: RehypePlugins = [
         if (!UI.externalLink.newTab || !UI.externalLink.showNewTabIcon)
           return null
 
-        // ignore remark-directive-sugar generated links
-        const elClass = el.properties.class
-        if (
-          elClass &&
-          typeof elClass === 'string' &&
-          elClass.includes('sugar-link')
-        )
-          return null
-
-        // ignore links containing images
         let hasImage = false
         visit(el, 'element', (childNode) => {
           if (childNode.tagName === 'img') {

--- a/plugins/remark-image-container.ts
+++ b/plugins/remark-image-container.ts
@@ -87,8 +87,7 @@ function remarkImageContainer() {
         const attributes = node.attributes || {}
 
         data.hName = 'a'
-        const defaultAttrs = { target: '_blank' }
-        data.hProperties = { ...defaultAttrs, ...attributes }
+        data.hProperties = attributes
       } else if (node.name.match(IMAGE_DIR_REGEXP)) {
         /* image-* */
         const match = node.name.match(IMAGE_DIR_REGEXP)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
       remark-directive:
         specifier: ^3.0.0
         version: 3.0.0

--- a/public/images/new-tab.svg
+++ b/public/images/new-tab.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 256 256">
+  <defs>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="6" stdDeviation="16" flood-color="black" flood-opacity="0.8" />
+    </filter>
+  </defs>
+  <path filter="url(#shadow)" fill="white" stroke="white" stroke-width="15"
+    d="M204 64v104a12 12 0 0 1-24 0V93L72.49 200.49a12 12 0 0 1-17-17L163 76H88a12 12 0 0 1 0-24h104a12 12 0 0 1 12 12" />
+  <path fill="currentColor"
+    d="M204 64v104a12 12 0 0 1-24 0V93L72.49 200.49a12 12 0 0 1-17-17L163 76H88a12 12 0 0 1 0-24h104a12 12 0 0 1 12 12" />
+</svg>

--- a/src/components/base/Footer.astro
+++ b/src/components/base/Footer.astro
@@ -1,9 +1,8 @@
 ---
-import Link from './Link.astro'
+import Link from '~/components/base/Link.astro'
 import { SITE } from '~/config'
 
 const currentYear = new Date().getFullYear()
-
 const copyrightText = `© ${currentYear} ${SITE.author}`
 ---
 
@@ -17,7 +16,6 @@ const copyrightText = `© ${currentYear} ${SITE.author}`
         <Link
           class="op-100! color-[--fg]!"
           href="https://github.com/lin-stephanie/astro-antfustyle-theme"
-          title="AntfuStyle on GitHub"
           external={true}
         >
           Astro AntfuStyle Theme

--- a/src/components/base/Link.astro
+++ b/src/components/base/Link.astro
@@ -5,16 +5,18 @@ import type { HTMLAttributes } from 'astro/types'
 interface Props extends HTMLAttributes<'a'> {
   href: string
   title?: string
-  external?: boolean
   rel?: string
+  external?: boolean
+  enableNewTabWarning?: boolean
   children: HTMLElement | HTMLElement[] | string
 }
 
 const {
   href,
   title,
-  external = false,
   rel,
+  external = false,
+  enableNewTabWarning = false,
   class: className,
   ...rest
 } = Astro.props
@@ -28,29 +30,57 @@ const relAttr =
     ? `${openInNewTab ? 'noopener noreferrer' : ''} ${rel ? rel : ''}`.trim()
     : undefined
 const ariaLabel = title ? title : openInNewTab ? 'Open in new tab' : undefined
+
+const showCursor =
+  openInNewTab &&
+  enableNewTabWarning &&
+  externalLink.cursorType &&
+  externalLink.cursorType !== 'pointer'
+
+const showIcon =
+  openInNewTab && enableNewTabWarning && externalLink.showNewTabIcon
 ---
 
 <a
-  class={className}
+  class:list={[
+    'op-60 no-underline hover:op-100',
+    className,
+    { 'external-link-cursor': showCursor },
+  ]}
   {href}
   {title}
   aria-label={ariaLabel}
-  target={targetAttr}
   rel={relAttr}
+  target={targetAttr}
   {...rest}
 >
-  <slot /></a
->
-
-<style>
-  a {
-    opacity: 0.6;
-    cursor: pointer;
-    text-decoration: none;
+  {
+    Astro.slots.has('default') && (
+      <>
+        <slot />
+        {showIcon && (
+          <span
+            u-i-carbon-arrow-up-right
+            class="new-tab-icon ml-0!"
+            aria-hidden="true"
+          />
+        )}
+      </>
+    )
   }
-
-  a:hover {
-    opacity: 1;
-    text-decoration-color: inherit;
+  {
+    Astro.slots.has('title') && (
+      <span class="text-lg leading-1.3em align-middle">
+        <slot name="title" />
+        {showIcon && (
+          <span
+            u-i-carbon-arrow-up-right
+            class="new-tab-icon ml--1! mb-1.8!"
+            aria-hidden="true"
+          />
+        )}
+      </span>
+    )
   }
-</style>
+  <slot name="end" />
+</a>

--- a/src/components/base/Link.astro
+++ b/src/components/base/Link.astro
@@ -6,16 +6,27 @@ interface Props extends HTMLAttributes<'a'> {
   href: string
   title?: string
   external?: boolean
+  rel?: string
   children: HTMLElement | HTMLElement[] | string
 }
 
-const { href, title, external = false, class: className, ...rest } = Astro.props
+const {
+  href,
+  title,
+  external = false,
+  rel,
+  class: className,
+  ...rest
+} = Astro.props
 
 const { externalLink } = UI
 
 const openInNewTab = external && externalLink.newTab
 const targetAttr = openInNewTab ? '_blank' : undefined
-const relAttr = openInNewTab ? 'noopener noreferrer' : undefined
+const relAttr =
+  rel || openInNewTab
+    ? `${openInNewTab ? 'noopener noreferrer' : ''} ${rel ? rel : ''}`.trim()
+    : undefined
 const ariaLabel = title ? title : openInNewTab ? 'Open in new tab' : undefined
 ---
 

--- a/src/components/base/Link.astro
+++ b/src/components/base/Link.astro
@@ -1,4 +1,5 @@
 ---
+import { UI } from '~/config'
 import type { HTMLAttributes } from 'astro/types'
 
 interface Props extends HTMLAttributes<'a'> {
@@ -10,15 +11,21 @@ interface Props extends HTMLAttributes<'a'> {
 
 const { href, title, external = false, class: className, ...rest } = Astro.props
 
-const newTitle = external && title ? `${title} (external link)` : title
+const { externalLink } = UI
+
+const openInNewTab = external && externalLink.newTab
+const targetAttr = openInNewTab ? '_blank' : undefined
+const relAttr = openInNewTab ? 'noopener noreferrer' : undefined
+const ariaLabel = title ? title : openInNewTab ? 'Open in new tab' : undefined
 ---
 
 <a
   class={className}
   {href}
-  title={newTitle}
-  target={external ? '_blank' : '_self'}
-  aria-label={newTitle}
+  {title}
+  aria-label={ariaLabel}
+  target={targetAttr}
+  rel={relAttr}
   {...rest}
 >
   <slot /></a

--- a/src/components/base/NavItem.astro
+++ b/src/components/base/NavItem.astro
@@ -1,7 +1,6 @@
 ---
-import Link from './Link.astro'
+import Link from '~/components/base/Link.astro'
 import { ensureTrailingSlash, getUrl } from '~/utils/common'
-
 import type { InternalNav, SocialLink } from '~/types'
 
 type Props =
@@ -128,6 +127,7 @@ const { type, item, mergeOnMobile, mobileItemType } = Astro.props
           class="lt-md:hidden op-transition"
           href={item.link}
           title={item.title}
+          rel="me"
           external={true}
         >
           {(item.displayMode === 'alwaysIcon' ||
@@ -149,16 +149,10 @@ const { type, item, mergeOnMobile, mobileItemType } = Astro.props
               class="block op-transition"
               href={item.link}
               title={item.title}
+              rel="me"
               external={true}
             >
-              <span>
-                {item.text}
-                <span
-                  u-i-carbon-arrow-up-right
-                  class="mb-2 mr--0.5 ml--1 op-50 align-middle text-xs"
-                  title="External link"
-                />
-              </span>
+              <span>{item.text}</span>
             </Link>
           </li>
         )
@@ -169,6 +163,7 @@ const { type, item, mergeOnMobile, mobileItemType } = Astro.props
             class="block op-transition"
             href={item.link}
             title={item.title}
+            rel="me"
             external={true}
           >
             <div class={item.icon} />
@@ -185,6 +180,7 @@ const { type, item, mergeOnMobile, mobileItemType } = Astro.props
         } op-transition`}
         href={item.link}
         title={item.title}
+        rel="me"
         external={true}
       >
         {(item.displayMode === 'alwaysText' ||

--- a/src/components/toc/Toc.astro
+++ b/src/components/toc/Toc.astro
@@ -1,4 +1,5 @@
 ---
+import Link from '~/components/base/Link.astro'
 import TocButton from '~/components/toc/TocButton.astro'
 import TocItem from '~/components/toc/TocItem.astro'
 import { slug } from '~/utils/common'
@@ -74,9 +75,9 @@ const specHeadings = generateToc(headings, minHeadingLevel, maxHeadingLevel)
           !!category.length &&
             category.map((item) => (
               <li>
-                <a href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
+                <Link href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
                   {item}
-                </a>
+                </Link>
               </li>
             ))
         }
@@ -84,9 +85,9 @@ const specHeadings = generateToc(headings, minHeadingLevel, maxHeadingLevel)
           !!years.length &&
             years.map((item) => (
               <li>
-                <a href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
+                <Link href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
                   {item}
-                </a>
+                </Link>
               </li>
             ))
         }
@@ -102,9 +103,9 @@ const specHeadings = generateToc(headings, minHeadingLevel, maxHeadingLevel)
         !!category.length &&
           category.map((item) => (
             <li>
-              <a href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
+              <Link href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
                 {item}
-              </a>
+              </Link>
             </li>
           ))
       }
@@ -112,9 +113,9 @@ const specHeadings = generateToc(headings, minHeadingLevel, maxHeadingLevel)
         !!years.length &&
           years.map((item) => (
             <li>
-              <a href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
+              <Link href={`#${slug(item)}`} aria-label={`Scroll to ${item}`}>
                 {item}
-              </a>
+              </Link>
             </li>
           ))
       }

--- a/src/components/toc/TocItem.astro
+++ b/src/components/toc/TocItem.astro
@@ -1,4 +1,5 @@
 ---
+import Link from '~/components/base/Link.astro'
 import type { TocHeading } from '~/utils/toc'
 
 interface Props {
@@ -12,9 +13,9 @@ const { slug, children, text } = heading
 <li>
   {
     slug && (
-      <a href={`#${slug}`} aria-label={`Scroll to ${text}`}>
+      <Link href={`#${slug}`} aria-label={`Scroll to ${text}`}>
         {text}
-      </a>
+      </Link>
     )
   }
   {

--- a/src/components/views/ListItem.astro
+++ b/src/components/views/ListItem.astro
@@ -1,5 +1,6 @@
 ---
 import Link from '~/components/base/Link.astro'
+
 import { getUrl } from '~/utils/common'
 import { formatDate } from '~/utils/datetime'
 
@@ -32,57 +33,46 @@ const {
 
 <div class="slide-enter" style={{ '--enter-stage': idx }}>
   <Link
-    class="block border-b-none! mb-6 mt-2 op-transition!"
+    u-flex="~ items-center lt-md:(col items-start) gap-2"
+    class="border-b-none! mb-6 mt-2 op-transition!"
     href={redirect ?? getUrl(`/${collectionType}/${postSlug}/`)}
     external={redirect ? true : false}
+    enableNewTabWarning={redirect ? true : false}
   >
-    <li
-      u-flex="~ items-center gap-2 lt-md:(col items-start)"
-      class="no-underline"
-    >
-      <div class="text-lg leading-1.2em">
-        <span class="align-middle"
-          >{title}
-          {
-            redirect && (
-              <span
-                u-i-carbon-arrow-up-right
-                class="mb-2 mr--0.5 ml--1 op-50 align-middle text-xs"
-                title="External link"
-              />
-            )
-          }</span
-        >
-      </div>
-      <div flex="~ gap-2 items-center">
-        {
-          video && (
-            <span
-              u-i-ri-film-line
-              class="flex-none op-50 align-middle"
-              title="Provided in video"
-            />
-          )
-        }
-        {
-          radio && (
-            <span
-              u-i-ri-radio-line
-              class="flex-none op-50 align-middle"
-              title="Provided in radio"
-            />
-          )
-        }
-        <span class="op-50 text-sm ws-nowrap">
-          {formatDate(date, false)}
-        </span>
-        {
-          typeof minutesRead === 'number' && minutesRead > 0 && (
-            <span class="op-40 text-sm ws-nowrap">· {minutesRead} min</span>
-          )
-        }
-        {platform && <span class="op-40 text-sm ws-nowrap">· {platform}</span>}
-      </div>
-    </li>
+    <Fragment slot="title">{title}</Fragment>
+    <span slot="end" u-flex="~ gap-2 items-center">
+      {
+        video && (
+          <span
+            u-i-ri-film-line
+            class="flex-none op-50 align-middle"
+            title="Provided in video"
+            aria-label="Provided in video"
+          />
+        )
+      }
+      {
+        radio && (
+          <span
+            u-i-ri-radio-line
+            class="flex-none op-50 align-middle"
+            title="Provided in radio"
+            aria-label="Provided in radio"
+          />
+        )
+      }
+      <time
+        class="op-50 text-sm ws-nowrap"
+        datetime={new Date(date).toISOString()}
+      >
+        {formatDate(date, false)}
+      </time>
+      {
+        typeof minutesRead === 'number' && minutesRead > 0 && (
+          <span class="op-40 text-sm ws-nowrap">· {minutesRead} min</span>
+        )
+      }
+      {platform && <span class="op-40 text-sm ws-nowrap">· {platform}</span>}
+    </span>
   </Link>
 </div>

--- a/src/components/views/ListView.astro
+++ b/src/components/views/ListView.astro
@@ -1,12 +1,14 @@
 ---
 import { getCollection, getEntry } from 'astro:content'
+
 import Categorizer from '~/components/base/Categorizer.astro'
 import ListItem from '~/components/views/ListItem.astro'
 import Toc from '~/components/toc/Toc.astro'
 import Warning from '~/components/base/Warning.astro'
+
+import { FEATURES } from '~/config'
 import { isSameYear, getYear } from '~/utils/datetime'
 import { getFilteredPosts, getSortedPosts } from '~/utils/post'
-import { FEATURES } from '~/config'
 
 import type {
   CollectionEntry,
@@ -112,7 +114,7 @@ const warningHTML = `The '${collectionType}' collection type does not
 
 {
   (collectionType === 'blog' || collectionType === 'changelog') && (
-    <ul aria-label="Post list">
+    <div aria-label="Post list">
       {sortedBlogItems.length === 0 ? (
         <div class="py-2 op-50">nothing here yet</div>
       ) : (
@@ -150,13 +152,13 @@ const warningHTML = `The '${collectionType}' collection type does not
           )
         })
       )}
-    </ul>
+    </div>
   )
 }
 
 {
   collectionType === 'streams' && (
-    <ul aria-label="Stream list">
+    <div aria-label="Stream list">
       {sortedStreamItems.length === 0 ? (
         <div class="py-2 op-50">nothing here yet</div>
       ) : (
@@ -187,13 +189,13 @@ const warningHTML = `The '${collectionType}' collection type does not
           )
         })
       )}
-    </ul>
+    </div>
   )
 }
 
 {
   collectionType === 'feeds' && (
-    <ul aria-label="Feed list">
+    <div aria-label="Feed list">
       {sortedFeedItems.length === 0 ? (
         <div class="py-2 op-50">nothing here yet</div>
       ) : (
@@ -231,7 +233,7 @@ const warningHTML = `The '${collectionType}' collection type does not
           )
         })
       )}
-    </ul>
+    </div>
   )
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,8 +85,8 @@ export const UI: Ui = {
   },
   externalLink: {
     newTab: true,
-    cursorType: '',
-    showNewTabIcon: true,
+    cursorType: 'url("/images/new-tab.svg") 10 10, pointer',
+    showNewTabIcon: false,
   },
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,11 @@ export const UI: Ui = {
       [/bluesky/, 'i-logos-bluesky'],
     ],
   },
+  externalLink: {
+    newTab: true,
+    cursorType: '',
+    showNewTabIcon: true,
+  },
 }
 
 /**

--- a/src/content/home/index.md
+++ b/src/content/home/index.md
@@ -47,52 +47,23 @@ This live demo will guide you through setup and customization, offering helpful 
   <a
     class="inline-block ml-1.5 op-75 hover:op-100"
     href="https://github.com/lin-stephanie/astro-antfustyle-theme"
-    target="_blank"
-    aria-label="AntfuStyle on GitHub (external link)"
   >
-    <span i-simple-icons-github></span>
-    GitHub repo
-  </a>
+  <span i-simple-icons-github></span> GitHub repo</a>
 </p>
 
 <p>
   <span class="inline-block mr-1.5 mb-2">Find me on</span>
   <span class="inline-flex flex-wrap gap-2 op-75 hover:op-100">
-    <a
-      href="https://github.com/lin-stephanie/astro-antfustyle-theme"
-      target="_blank"
-      aria-label="Find me on GitHub (external link)"
-    >
-      <span i-simple-icons-github></span> GitHub
-    </a>
-    <a
-      href="https://github.com/lin-stephanie/astro-antfustyle-theme"
-      target="_blank"
-      aria-label="Find me on Twitter (external link)"
-    >
-      <span i-ri-twitter-x-fill></span> Twitter
-    </a>
-    <a
-      href="https://github.com/lin-stephanie/astro-antfustyle-theme"
-      target="_blank"
-      aria-label="Find me on Instagram (external link)"
-    >
-      <span i-simple-icons-instagram></span> Instagram
-    </a>
-    <a
-      href="https://github.com/lin-stephanie/astro-antfustyle-theme"
-      target="_blank"
-      aria-label="Find me on Mastodon (external link)"
-    >
-      <span i-simple-icons-mastodon></span> Mastodon
-    </a>
-    <a
-      href="https://github.com/lin-stephanie/astro-antfustyle-theme"
-      target="_blank"
-      aria-label="Find me on YouTube (external link)"
-    >
-      <span i-simple-icons-youtube></span> YouTube
-    </a>
+    <a href="https://github.com/lin-stephanie/astro-antfustyle-theme">
+      <span i-simple-icons-github></span> GitHub</a>
+    <a href="https://github.com/lin-stephanie/astro-antfustyle-theme">
+      <span i-ri-twitter-x-fill></span> Twitter</a>
+    <a href="https://github.com/lin-stephanie/astro-antfustyle-theme">
+      <span i-simple-icons-instagram></span> Instagram</a>
+    <a href="https://github.com/lin-stephanie/astro-antfustyle-theme">
+      <span i-simple-icons-mastodon></span> Mastodon</a>
+    <a href="https://github.com/lin-stephanie/astro-antfustyle-theme">
+      <span i-simple-icons-youtube></span> YouTube</a>
   </span>
 </p>
 
@@ -101,22 +72,8 @@ This live demo will guide you through setup and customization, offering helpful 
 If you find this theme helpful, consider supporting the project maintainer or the style designer. Your support means more than you know. Thank you! ❤️
 
 <div class="flex flex-wrap gap-4">
-  <a
-    class="btn-rose"
-    href="https://github.com/sponsors/lin-stephanie"
-    target="_blank"
-    aria-label="Support Stephanie Lin (external link)"
-  >
-    <div class="i-ph-heart-duotone transition-all ease-out duration-200"></div>
-    Support Stephanie Lin (Maintainer)
-  </a>
-  <a
-    class="btn-yellow"
-    href="https://github.com/sponsors/antfu"
-    target="_blank"
-    aria-label="Support Anthony Fu (external link)"
-  >
-    <div class="i-ph-lightning-duotone transition-all ease-out duration-200"></div>
-    Support Anthony Fu (Designer)
-  </a>
+  <a class="btn-rose" href="https://github.com/sponsors/lin-stephanie">
+    <span class="i-ph-heart-duotone"></span> Support Stephanie Lin (Maintainer)</a>
+  <a class="btn-yellow" href="https://github.com/sponsors/antfu">
+    <span class="i-ph-lightning-duotone"></span> Support Anthony Fu (Designer)</a>
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ import Footer from '~/components/base/Footer.astro'
 import ToTopButton from '~/components/widgets/ToTopButton.astro'
 import Backdrop from '~/components/base/Backdrop.astro'
 
-import { SITE, FEATURES } from '~/config'
+import { SITE, UI, FEATURES } from '~/config'
 import { getUrl } from '~/utils/common'
 
 import type { BgType } from '~/types'
@@ -31,11 +31,17 @@ interface Props {
 const { title, description, ogImage, bgType, pubDate, lastModDate } =
   Astro.props
 
+let style: Record<string, string> = {}
+
 const { slideEnterAnim } = FEATURES
-const slideEnterAnimEnabled = Array.isArray(slideEnterAnim) && slideEnterAnim[0]
-const style = slideEnterAnimEnabled
-  ? { '--enter-step': `${slideEnterAnim[1].enterStep}ms` }
-  : undefined
+const enableSlideEnterAnim = Array.isArray(slideEnterAnim) && slideEnterAnim[0]
+if (enableSlideEnterAnim)
+  style['--enter-step'] = `${slideEnterAnim[1].enterStep}ms`
+
+const { externalLink } = UI
+const hasCustomCursor =
+  externalLink.cursorType.length > 0 && externalLink.cursorType !== 'pointer'
+if (hasCustomCursor) style['--external-link-cursor'] = externalLink.cursorType
 ---
 
 <!doctype html>
@@ -47,8 +53,8 @@ const style = slideEnterAnimEnabled
   <body
     class="relative flex flex-col min-h-screen
       font-sans text-gray-700 dark:text-gray-200"
-    data-no-sliding={!slideEnterAnimEnabled ? true : undefined}
-    {style}
+    style={Object.keys(style).length !== 0 ? style : undefined}
+    data-no-sliding={!enableSlideEnterAnim ? true : undefined}
   >
     <!-- Background -->
     {bgType && <Background type={bgType} />}

--- a/src/pages/projects.mdx
+++ b/src/pages/projects.mdx
@@ -10,6 +10,8 @@ ogImage: false
 import BaseLayout from '~/layouts/BaseLayout.astro'
 import StandardLayout from '~/layouts/StandardLayout.astro'
 import GroupView from '~/components/views/GroupView.astro'
+import Link from '~/components/base/Link.astro'
+
 import { getUrl } from '~/utils/common'
 
 <BaseLayout
@@ -24,14 +26,14 @@ import { getUrl } from '~/utils/common'
     isCentered={true}
   >
     <div slot="head" class="flex flex-wrap justify-center items-center gap-4">
-      <a class="btn-orange" href={getUrl('/releases/')}>
-        <div class="i-ph-rocket-launch-duotone transition-all ease-out duration-200"></div>
-        <p class="inline-block my-0! ml-1.5">Latest Releases</p>
-      </a>
-      <a class="btn-violet" href={getUrl('/prs/')}>
-        <div class="i-lucide-git-pull-request transition-all ease-out duration-200"></div>
-        <p class="inline-block my-0! ml-1.5">Recent Pull Requests</p>
-      </a>
+      <Link class="btn-orange" href={getUrl('/releases/')}>
+        <span class="i-ph-rocket-launch-duotone"></span>
+        <span class="ml-1.5">Latest Releases</span>
+      </Link>
+      <Link class="btn-violet" href={getUrl('/prs/')}>
+        <span class="i-lucide-git-pull-request"></span>
+        <span class="ml-1.5">Recent Pull Requests</span>
+      </Link>
     </div>
     <GroupView slot="wide" pageToc={frontmatter.toc} />
   </StandardLayout>

--- a/src/pages/prs.mdx
+++ b/src/pages/prs.mdx
@@ -10,6 +10,7 @@ ogImage: true
 import BaseLayout from '~/layouts/BaseLayout.astro'
 import StandardLayout from '~/layouts/StandardLayout.astro'
 import GithubView from '~/components/views/GithubView.astro'
+import Link from '~/components/base/Link.astro'
 
 <BaseLayout
   title={frontmatter.title}
@@ -22,7 +23,7 @@ import GithubView from '~/components/views/GithubView.astro'
       <h1 class="ml-12 lt-sm:ml-0"
       >AstroEco is <span class="animate-pulse">Contributing...</span></h1>
       <p class="mt--4! op-50 italic"
-      >Example: Displaying GitHub pull requests using <a href="https://github.com/lin-stephanie/astro-loaders/tree/main/packages/astro-loader-github-prs" target="_blank">astro-loader-github-prs</a></p>
+      >Example: Displaying GitHub pull requests using <Link href="https://github.com/lin-stephanie/astro-loaders/tree/main/packages/astro-loader-github-prs" external={true}>astro-loader-github-prs</Link></p>
     </Fragment>
     <GithubView slot="github" collectionType="prs" />
   </StandardLayout>

--- a/src/pages/releases.mdx
+++ b/src/pages/releases.mdx
@@ -10,6 +10,7 @@ ogImage: true
 import BaseLayout from '~/layouts/BaseLayout.astro'
 import StandardLayout from '~/layouts/StandardLayout.astro'
 import GithubView from '~/components/views/GithubView.astro'
+import Link from '~/components/base/Link.astro'
 
 <BaseLayout
   title={frontmatter.title}
@@ -22,7 +23,7 @@ import GithubView from '~/components/views/GithubView.astro'
       <h1 class="ml-12 lt-sm:ml-0"
       >AstroEco is <span class="animate-pulse">Releasing...</span></h1>
       <p class="mt--4! op-50 italic"
-      >Example: Displaying GitHub releases using <a href="https://github.com/lin-stephanie/astro-loaders/tree/main/packages/astro-loader-github-releases" target="_blank">astro-loader-github-releases</a></p>
+      >Example: Displaying GitHub releases using <Link href="https://github.com/lin-stephanie/astro-loaders/tree/main/packages/astro-loader-github-releases" external={true}>astro-loader-github-releases</Link></p>
     </Fragment>
     <GithubView slot="github" collectionType="releases" />
   </StandardLayout>

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -365,7 +365,6 @@ html:not(.dark) .img-dark {
 /* :link */
 .sugar-link-square {
   display: inline-flex;
-  gap: 0.25rem;
   align-items: center;
   padding: 0.25rem 0.375rem;
   border-radius: 0.25rem;
@@ -381,9 +380,8 @@ html:not(.dark) .img-dark {
 
 .sugar-link-rounded {
   display: inline-flex;
-  gap: 0.3rem;
   align-items: center;
-  padding: 0 0.5rem 0 0;
+  padding-right: 0.5rem;
   border-radius: 9999px;
   border-width: 0px !important;
 
@@ -407,6 +405,7 @@ html:not(.dark) .img-dark {
   height: 1.1em;
   width: 1.1em;
   border-radius: 2px;
+  margin-right: 0.25rem;
 
   background-size: cover;
   background-repeat: no-repeat;
@@ -444,4 +443,24 @@ html:not(.dark) .img-dark {
 
 .dark .sugar-badge {
   background-color: var(--badge-color-dark);
+}
+
+/* rehype-external-links */
+.new-tab-icon {
+  margin-left: 0.05rem;
+  margin-bottom: 0.3rem;
+
+  opacity: 0.3;
+  transition: opacity 0.3s ease-in-out;
+
+  font-size: 0.6em;
+}
+
+a:hover .new-tab-icon,
+a:focus .new-tab-icon {
+  opacity: 1;
+}
+
+.external-link-cursor {
+  cursor: var(--external-link-cursor);
 }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -376,6 +376,7 @@ html:not(.dark) .img-dark {
 
   background: #8882;
   transform: translateY(3px);
+  transition: all 300ms ease-in-out !important;
 }
 
 .sugar-link-rounded {
@@ -392,6 +393,7 @@ html:not(.dark) .img-dark {
 
   background: #8882;
   transform: translateY(6px);
+  transition: all 300ms ease-in-out !important;
 }
 
 .sugar-link-square:hover,

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -449,18 +449,10 @@ html:not(.dark) .img-dark {
 
 /* rehype-external-links */
 .new-tab-icon {
-  margin-left: 0.05rem;
+  margin-left: 0.1rem;
   margin-bottom: 0.3rem;
 
-  opacity: 0.3;
-  transition: opacity 0.3s ease-in-out;
-
   font-size: 0.6em;
-}
-
-a:hover .new-tab-icon,
-a:focus .new-tab-icon {
-  opacity: 1;
 }
 
 .external-link-cursor {

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,7 +389,8 @@ export interface GitHubView {
 interface ExternalLink {
   /**
    * Controls whether external links are opened in a new tab.
-   * Used in `src/components/base/Link.astro` and `plugins/index.ts`.
+   *
+   * Used in `plugins/index.ts` and `src/components/base/Link.astro`.
    */
   newTab: boolean
 
@@ -399,11 +400,18 @@ interface ExternalLink {
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#url custom URLs},
    * or an empty string to default to `'pointer'` for matching internal links.
    *
-   * Used in `plugins/index.ts`, it only applies to external links generated from
-   * `[]()` syntax in Markdown / MDX, not direct `<a>` elements.
+   * It handles external links from `[]()` in Markdown/MDX,
+   * not direct `<a>` elements. To process `<a>` elements, install `rehype-raw`
+   * and configure it before `rehype-external-links`.
+   *
+   * To apply it to other external links in the site's UI,
+   * set `enableNewTabWarning: true` in `src/components/base/Link.astro`
+   * or pass it locally to the `Link` component as needed.
+   *
+   * Used in `plugins/index.ts`, `src/layouts/BaseLayout.astro` and `src/components/base/Link.astro`.
    *
    * @example
-   * 'url("/images/new-tab.png") 10 10, pointer'
+   * 'url("/images/new-tab.svg") 10 10, pointer'
    */
   cursorType: string
 
@@ -412,8 +420,15 @@ interface ExternalLink {
    * showing they open in a new tab for accessibility.
    * Skip this if `cursorType` already uses an image for the same purpose.
    *
-   * Used in `plugins/index.ts`, it only applies to external links generated from
-   * `[]()` syntax in Markdown / MDX, not direct `<a>` elements.
+   * It handles external links from `[]()` in Markdown/MDX,
+   * not direct `<a>` elements. To process `<a>` elements, install `rehype-raw`
+   * and configure it before `rehype-external-links`.
+   *
+   * To apply it to other external links in the site's UI,
+   * set `enableNewTabWarning: true` in `src/components/base/Link.astro`
+   * or pass it locally to the `Link` component as needed.
+   *
+   * Used in `plugins/index.ts` and `src/components/base/Link.astro`.
    */
   showNewTabIcon: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -386,6 +386,38 @@ export interface GitHubView {
   subLogoMatches: [RepoWithOwner | RegExp, Url | Icon][]
 }
 
+interface ExternalLink {
+  /**
+   * Controls whether external links are opened in a new tab.
+   * Used in `src/components/base/Link.astro` and `plugins/index.ts`.
+   */
+  newTab: boolean
+
+  /**
+   * Specifies the cursor type for external links.
+   * Accepts {@link https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#keyword standard keywords},
+   * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#url custom URLs},
+   * or an empty string to default to `'pointer'` for matching internal links.
+   *
+   * Used in `plugins/index.ts`, it only applies to external links generated from
+   * `[]()` syntax in Markdown / MDX, not direct `<a>` elements.
+   *
+   * @example
+   * 'url("/images/new-tab.png") 10 10, pointer'
+   */
+  cursorType: string
+
+  /**
+   * Controls whether to add an indicator to external links when `newTab` is `true`,
+   * showing they open in a new tab for accessibility.
+   * Skip this if `cursorType` already uses an image for the same purpose.
+   *
+   * Used in `plugins/index.ts`, it only applies to external links generated from
+   * `[]()` syntax in Markdown / MDX, not direct `<a>` elements.
+   */
+  showNewTabIcon: boolean
+}
+
 export interface Ui {
   /**
    * Configures internal navigation links, used in `src/components/base/NavBar.astro`.
@@ -426,6 +458,11 @@ export interface Ui {
    * Configures the `/releases` and `prs` UIs, used in `src/components/views/GithubView.astro`.
    */
   githubView: GitHubView
+
+  /**
+   * Configures external links' behavior and appearance.
+   */
+  externalLink: ExternalLink
 }
 
 /* FEATURES */

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,13 +400,9 @@ interface ExternalLink {
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#url custom URLs},
    * or an empty string to default to `'pointer'` for matching internal links.
    *
-   * It handles external links from `[]()` in Markdown/MDX,
-   * not direct `<a>` elements. To process `<a>` elements, install `rehype-raw`
-   * and configure it before `rehype-external-links`.
-   *
    * To apply it to other external links in the site's UI,
-   * set `enableNewTabWarning: true` in `src/components/base/Link.astro`
-   * or pass it locally to the `Link` component as needed.
+   * set `enableNewTabWarning` to `true` in `src/components/base/Link.astro`
+   * or locally pass `enableNewTabWarning: true` to the Link component as needed.
    *
    * Used in `plugins/index.ts`, `src/layouts/BaseLayout.astro` and `src/components/base/Link.astro`.
    *
@@ -420,13 +416,9 @@ interface ExternalLink {
    * showing they open in a new tab for accessibility.
    * Skip this if `cursorType` already uses an image for the same purpose.
    *
-   * It handles external links from `[]()` in Markdown/MDX,
-   * not direct `<a>` elements. To process `<a>` elements, install `rehype-raw`
-   * and configure it before `rehype-external-links`.
-   *
    * To apply it to other external links in the site's UI,
-   * set `enableNewTabWarning: true` in `src/components/base/Link.astro`
-   * or pass it locally to the `Link` component as needed.
+   * set `enableNewTabWarning` to `true` in `src/components/base/Link.astro`
+   * or locally pass `enableNewTabWarning: true` to the Link component as needed.
    *
    * Used in `plugins/index.ts` and `src/components/base/Link.astro`.
    */


### PR DESCRIPTION
## Description

- Support control over opening links in the current tab or a new tab (applies to links from Markdown/MDX `[]()` syntax and the `Link` component)
- Support with custom cursor or indicator icon for new tab links (applies to links from Markdown/MDX `[]()` syntax)
- Update `rehype-external-links` config
- Update `BaseLayout` to toggle `--external-link-cursor` on body
