### PR TITLE
feat: improve icon resolution in `:link` directive

### DIFF
--- a/plugins/remark-directive-sugar.ts
+++ b/plugins/remark-directive-sugar.ts
@@ -26,7 +26,8 @@ const VIDEO_PLATFORMS: Record<string, (id: string) => string> = {
 }
 
 /* link */
-const FAVICON_BASE_URL = 'https://favicon.yandex.net/favicon/'
+const FAVICON_BASE_URL = 'https://www.google.com/s2/favicons'
+const FAVICON_RESOLUTION = 128
 const GITHUB_USERNAME_REGEXP =
   /^@[a-zA-Z0-9](?!.*--)[a-zA-Z0-9-_]{0,37}[a-zA-Z0-9]$/
 const GITHUB_REPO_REGEXP =
@@ -220,7 +221,8 @@ function remarkDirectiveSugar() {
             // non github scope
             resolvedLink = link
             resolvedImageUrl =
-              imageUrl || `${FAVICON_BASE_URL}${new URL(resolvedLink).hostname}`
+              imageUrl ||
+              `${FAVICON_BASE_URL}?domain=${new URL(resolvedLink).hostname}&sz=${FAVICON_RESOLUTION}`
             resolvedStyle = resolvedStyle || 'square'
           } else if (id) {
             // github scope


### PR DESCRIPTION
## Description

The icon of `:link` directive (External URL variant) used `favicon.yandex.net` to obtain the icon, which is `16 x 16` by default. This PR improves the resolution of icons using Google's API.

<!-- Instructions and suggestions for crafting your PR -->

<!----------------------------------------------------------------------
- Please structure the PR title as `<type>[optional scope]: <description>`.
- Clearly list the problem addressed, the reason for the change, and the implementation approach.
- If this PR resolves an issue, include `resolves #number`.
- If there are visual changes, consider attaching before/after screenshots.
- Update necessary documentation or add a new post detailing the changes.
- Are there any parts you think require more attention from me?
----------------------------------------------------------------------->

<!-- Response times may vary, but I aim to be as prompt as possible. -->

<!-- Thank you for contributing! Your efforts are appreciated. 🙌 -->
