### PR TITLE
Fix: Update Toc.astro to support Chinese text anchors

### DIFF
--- a/src/components/toc/Toc.astro
+++ b/src/components/toc/Toc.astro
@@ -215,7 +215,7 @@ const specHeadings = generateToc(headings, minHeadingLevel, maxHeadingLevel)
     #generateHeadingMapToc = (tocLinks: HTMLAnchorElement[]) => {
       for (const link of tocLinks) {
         const { hash } = new URL(link.href)
-        const id = hash.replace(/^#/, '')
+        const id = decodeURIComponent(hash.replace(/^#/, ''))
         const headingEl = document.getElementById(id)
 
         if (headingEl) {


### PR DESCRIPTION
## Description

This PR updates the `Toc.astro` to properly support Chinese text anchors. Previously, the anchor links did not account for percent-encoded Chinese characters. As a result, headings containing Chinese text were not correctly recognized.

<!-- Instructions and suggestions for crafting your PR -->

<!----------------------------------------------------------------------
- Please structure the PR title as `<type>[optional scope]: <description>`.
- Clearly list the problem addressed, the reason for the change, and the implementation approach.
- If this PR resolves an issue, include `resolves #number`.
- If there are visual changes, consider attaching before/after screenshots.
- Update necessary documentation or add a new post detailing the changes.
- Are there any parts you think require more attention from me?
----------------------------------------------------------------------->

<!-- Response times may vary, but I aim to be as prompt as possible. -->

<!-- Thank you for contributing! Your efforts are appreciated. 🙌 -->
